### PR TITLE
Fix string matching to be non-greedy

### DIFF
--- a/syntaxes/latte.tmLanguage
+++ b/syntaxes/latte.tmLanguage
@@ -127,13 +127,13 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>(')(.*)(')</string>
+					<string>(')(.*?)(')</string>
 					<key>name</key>
 					<string>string.quoted.single.latte</string>
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(")(.*)(")</string>
+					<string>(")(.*?)(")</string>
 					<key>name</key>
 					<string>string.quoted.double.latte</string>
 				</dict>


### PR DESCRIPTION
Fixes string matching from this:

![image](https://user-images.githubusercontent.com/6860713/27082663-f19a4474-5045-11e7-8b8f-9a4cfd479530.png)

To this:

![image](https://user-images.githubusercontent.com/6860713/27082669-f473bacc-5045-11e7-8153-e9991d7931b9.png)
