### PR TITLE
Support {switch} statements

### DIFF
--- a/syntaxes/latte.tmLanguage
+++ b/syntaxes/latte.tmLanguage
@@ -69,13 +69,13 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(?&lt;=\{)(_|breakIf|continueIf|contentType|control|debugbreak|default|dump|elseifset|elseif|else|extends|includeblock|include|inputError|input|layout|link|php|plink|r|status|use|var)\s*</string>
+					<string>(?&lt;=\{)(_|breakIf|case|continueIf|contentType|control|debugbreak|default|dump|elseifset|elseif|else|extends|includeblock|include|inputError|input|layout|link|php|plink|r|status|use|var)\s*</string>
 					<key>name</key>
 					<string>keyword.control.single.latte</string>
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>(?&lt;=\{)/?(block|cache|capture|define|first|foreach|form|for|ifset|ifCurrent|if|label|last|l|sep|snippet|syntax|while)\s*</string>
+					<string>(?&lt;=\{)/?(block|cache|capture|define|first|foreach|form|for|ifset|ifCurrent|if|label|last|l|sep|snippet|switch|syntax|while)\s*</string>
 					<key>name</key>
 					<string>keyword.control.pair.latte</string>
 				</dict>


### PR DESCRIPTION
Enable syntax highlighting of switch statements, e.g.

```
{switch $type}
  {case image}
    ...
  {case video}
    ...
  {default}
    ...
{/switch}
```