### PR TITLE
Removed lineComment for Latte

### DIFF
--- a/latte.configuration.json
+++ b/latte.configuration.json
@@ -1,7 +1,5 @@
 {
 	"comments": {
-		// symbol used for single line comment. Remove this entry if your language does not support line comments
-		"lineComment": "//",
 		// symbols used for start and end a block comment. Remove this entry if your language does not support block comments
 		"blockComment": [ "{*", "*}" ]
 	},


### PR DESCRIPTION
According to Latte docs (https://latte.nette.org/en/tags), only block comment "{*" "*}" is valid. VSCode uses block comment for single lines if no lineComment is specified, thus allowing default shortcuts like CTR+/ to be used for commenting single or multiple lines