### PR TITLE
Add Region Folding

### DIFF
--- a/latte.configuration.json
+++ b/latte.configuration.json
@@ -8,5 +8,11 @@
     ["{", "}"],
     ["[", "]"],
     ["(", ")"]
-  ]
+  ],
+  "folding": {
+    "markers": {
+      "start": "^\\s*#\\s*region\\b",
+      "end": "^\\s*#\\s*endregion\\b"
+    }
+  }
 }

--- a/neon.configuration.json
+++ b/neon.configuration.json
@@ -8,5 +8,11 @@
     ["{", "}"],
     ["[", "]"],
     ["(", ")"]
-  ]
+  ],
+  "folding": {
+    "markers": {
+      "start": "^\\s*#\\s*region\\b",
+      "end": "^\\s*#\\s*endregion\\b"
+    }
+  }
 }


### PR DESCRIPTION
When I use tools like PHPStan, which can generate a baseline that results in a Neon list of thousands of elements, it's super useful to be able to organize and group the list, but the grouping has to be done in a way that does not require indentation, as that changes the meaning of the text.

This PR allows developers to add `#region` and `#endregion` comments to make a section of code foldable.

<img width="941" height="344" alt="image" src="https://github.com/user-attachments/assets/9caad45e-23e9-4af5-a308-61e5db2b9ded" />
